### PR TITLE
Corrected GST_SDK set statement

### DIFF
--- a/pithos.bat
+++ b/pithos.bat
@@ -37,7 +37,7 @@ REM Detect GStreamer SDK
 set GST_VIA=environment
 set GST_SDK=N
 if defined GSTREAMER_SDK_ROOT_X86 set GST_SDK=%GSTREAMER_SDK_ROOT_X86%
-if defined GSTREAMER_SDK_ROOT_X86_64 set GST_SDK=%GSTREAMER_SDK_ROOT_X64%
+if defined GSTREAMER_SDK_ROOT_X86_64 set GST_SDK=%GSTREAMER_SDK_ROOT_X86_64%
 
 if not "%GST_SDK%" == "N" goto pygst_env_found
 


### PR DESCRIPTION
GSTREAMER environment variable set wrong for 64 installation.

Change set statement on line 40 from 
set GST_SDK=%GSTREAMER_SDK_ROOT_X64%
to 
set GST_SDK=%GSTREAMER_SDK_ROOT_X86_64%
